### PR TITLE
Add functions to return perlin noise in numpy arrays.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+1.1.5 -- December 14, 2019
+
+    - Add functionality to return arrays of Perlin noise.
+
 1.1.4 -- August 1, 2017
 
   - Fix Python 3 crash

--- a/__init__.py
+++ b/__init__.py
@@ -8,7 +8,7 @@ Copyright (c) 2008, Casey Duncan (casey dot duncan at gmail dot com)
 Copyright (c) 2017, Zev Benjamin <zev@strangersgate.com>
 """
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 
 from . import _perlin, _simplex
 
@@ -18,3 +18,7 @@ snoise4 = _simplex.noise4
 pnoise1 = _perlin.noise1
 pnoise2 = _perlin.noise2
 pnoise3 = _perlin.noise3
+
+pnoisearr1 = _perlin.noisearr1
+pnoisearr2 = _perlin.noisearr2
+pnoisearr3 = _perlin.noisearr3

--- a/_perlin.c
+++ b/_perlin.c
@@ -115,9 +115,9 @@ py_arr_noise1(PyObject *self, PyObject *args, PyObject *kwargs)
         for (int i = 0; i < x_res; i++) {
 	            data[i] = noise1(x + i/x_res, repeat, base);
         }
-		return ret;
-	} else if (octaves > 1) {
-        for (int i = 0; i < x_res; i++) {
+	return ret;
+	} else {
+	    for (int i = 0; i < x_res; i++) {
             int j;
             float freq = 1.0f;
             float amp = 1.0f;
@@ -259,7 +259,7 @@ py_arr_noise2(PyObject *self, PyObject *args, PyObject *kwargs)
 	        }
 	    }
 		return ret;
-	} else if (octaves > 1) {
+	} else {
         for (int i = 0; i < height; i++) {
 	        // Iterate over each row.
 	        int rowIndex = width * i;
@@ -430,7 +430,7 @@ py_arr_noise3(PyObject *self, PyObject *args, PyObject *kwargs)
 	        }
 	    }
 		return ret;
-	} else if (octaves > 1) {
+	} else {
         for (int i = 0; i < z_size; i++) {
 	        // Iterate over each row.
 	        int planeIndex = x_size * y_size * i;

--- a/_perlin.c
+++ b/_perlin.c
@@ -5,9 +5,12 @@
 // see LICENSE.txt for details
 
 #include "Python.h"
+#include "numpy/arrayobject.h"
 #include <math.h>
 #include <stdio.h>
 #include "_noise.h"
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 #ifdef _MSC_VER
 #define inline __inline
@@ -527,6 +530,9 @@ static struct PyModuleDef moduledef = {
 PyObject *
 PyInit__perlin(void)
 {
+    if(PyArray_API == NULL)
+        import_array();
+
     return PyModule_Create(&moduledef);
 }
 
@@ -535,6 +541,9 @@ PyInit__perlin(void)
 void
 init_perlin(void)
 {
+    if(PyArray_API == NULL)
+        import_array();
+
     Py_InitModule3("_perlin", perlin_functions, module_doc);
 }
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ else:
 
 setup(
     name='vec_noise',
-    version='1.1.4',
+    version='1.1.5',
     description='Vectorized Perlin noise for Python',
     long_description='''\
 This is a fork of Casey Duncan's noise library that vectorizes all of the noise

--- a/test.py
+++ b/test.py
@@ -28,6 +28,8 @@ class PerlinTestCase(unittest.TestCase):
         from vec_noise._perlin import noisearr1
         import numpy as np
         from random import randint
+        from vec_noise import pnoise1
+        
         size = 100
         noise_map = np.zeros(size)
 
@@ -58,6 +60,8 @@ class PerlinTestCase(unittest.TestCase):
         from vec_noise._perlin import noisearr2
         import numpy as np
         from random import randint
+        from vec_noise import pnoise2 
+    
         size = (100, 100)
         noise_map = np.zeros(size)
 
@@ -68,7 +72,7 @@ class PerlinTestCase(unittest.TestCase):
             for j in range(size[1]):
                 noise_map[i][j] = pnoise2(i1, j + offset_y)
         
-        self.assertTrue(np.allclose(noise_map, noisearr2(offset_x, offset_y, size[0], size[1], size[0], size[1])))
+        self.assertTrue(np.allclose(noise_map, noisearr2(offset_x, offset_y, size[0], size[1], 1, 1)))
         
     def test_perlin_2d_base(self):
         from vec_noise import pnoise2

--- a/test.py
+++ b/test.py
@@ -24,6 +24,19 @@ class PerlinTestCase(unittest.TestCase):
         self.assertNotEqual(pnoise1(0.5), pnoise1(0.5, base=5))
         self.assertNotEqual(pnoise1(0.5, base=5), pnoise1(0.5, base=1))
 
+    def test_perlin_1d_base_array(self):
+        from vec_noise._perlin import noisearr1
+        import numpy as np
+        from random import randint
+        size = 100
+        noise_map = np.zeros(size)
+
+        offset_x = randint(0, 10000)
+        for i in range(size):
+            noise_map[i] = pnoise1(offset_x + i)
+        
+        self.assertTrue(np.allclose(noise_map, noisearr1(offset_x, size, size)))
+
     def test_perlin_2d_range(self):
         from vec_noise import pnoise2
         for i in range(-10000, 10000):
@@ -41,6 +54,22 @@ class PerlinTestCase(unittest.TestCase):
                 n = pnoise2(x, y, octaves=o + 1)
                 self.assertTrue(-1.0 <= n <= 1.0, (x, n))
 
+    def test_perlin_2d_base_array(self):
+        from vec_noise._perlin import noisearr2
+        import numpy as np
+        from random import randint
+        size = (100, 100)
+        noise_map = np.zeros(size)
+
+        offset_x, offset_y = randint(0, 10000), randint(0, 10000)
+
+        for i in range(size[0]):
+            i1 = i + offset_x
+            for j in range(size[1]):
+                noise_map[i][j] = pnoise2(i1, j + offset_y)
+        
+        self.assertTrue(np.allclose(noise_map, noisearr2(offset_x, offset_y, size[0], size[1], size[0], size[1])))
+        
     def test_perlin_2d_base(self):
         from vec_noise import pnoise2
         x, y = 0.73, 0.27


### PR DESCRIPTION
Since the perlin noise functions have known dimensions, I decided to just use for loops to index into their respective arrays and skip the use of an iterator.
The functions add size and resolution - size for the dimensions of the output, and resolution to determine the distance travelled along an axis - eg. if I specify a size of 10 and a resolution of 10, each element will be 1 unit away from the last.

I wasn't sure whether tuples should be used for specifying these variables, so I just stuck with what was done.